### PR TITLE
Fixed plugin registration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Register the plugin in your OpenCode configuration:
 
 ```jsonc
 {
-  "plugins": ["github:@thatguyinabeanie/opencode-subagent-logging"],
+  "plugin": ["github@thatguyinabeanie/opencode-subagent-logging"]
 }
 ```
 


### PR DESCRIPTION
Fixed plugin registration instructions in README.md. Now it works correctly.